### PR TITLE
Optimize .mark_as_read! and extend to work on relations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
+*.log
 .bundle
 Gemfile.lock
 gemfiles/*.lock

--- a/lib/generators/unread/generator_helper.rb
+++ b/lib/generators/unread/generator_helper.rb
@@ -1,0 +1,13 @@
+module Unread
+  module Generators
+    module GeneratorHelper
+      def next_migration_number(dirname)
+        if ActiveRecord::Base.timestamped_migrations
+          Time.now.utc.strftime("%Y%m%d%H%M%S")
+        else
+          "%.3d" % (current_migration_number(dirname) + 1)
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/unread/migration_helper.rb
+++ b/lib/generators/unread/migration_helper.rb
@@ -1,0 +1,16 @@
+module Unread
+  module Generators
+    module MigrationHelper
+      def mysql?
+        defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) \
+          && ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+      end
+
+      def postgresql_9_5?
+        defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) \
+          && ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) \
+          && ActiveRecord::Base.connection.send(:postgresql_version) >= 90500
+      end
+    end
+  end
+end

--- a/lib/generators/unread/polymorphic_reader_migration/polymorphic_reader_migration_generator.rb
+++ b/lib/generators/unread/polymorphic_reader_migration/polymorphic_reader_migration_generator.rb
@@ -1,23 +1,17 @@
 require 'rails/generators'
 require 'rails/generators/migration'
+require 'generators/unread/generator_helper'
 
 module Unread
   class PolymorphicReaderMigrationGenerator < Rails::Generators::Base
     include Rails::Generators::Migration
+    extend Unread::Generators::GeneratorHelper
 
     desc "Generates update migration to make reader of read_markers polymorphic"
     source_root File.expand_path('../templates', __FILE__)
 
     def create_migration_file
       migration_template 'unread_polymorphic_reader_migration.rb', 'db/migrate/unread_polymorphic_reader_migration.rb'
-    end
-
-    def self.next_migration_number(dirname)
-      if ActiveRecord::Base.timestamped_migrations
-        Time.now.utc.strftime("%Y%m%d%H%M%S")
-      else
-        "%.3d" % (current_migration_number(dirname) + 1)
-      end
     end
   end
 end

--- a/lib/generators/unread/postgresql_unique_constraint_migration/postgresql_unique_constraint_migration_generator.rb
+++ b/lib/generators/unread/postgresql_unique_constraint_migration/postgresql_unique_constraint_migration_generator.rb
@@ -3,15 +3,15 @@ require 'rails/generators/migration'
 require 'generators/unread/generator_helper'
 
 module Unread
-  class MigrationGenerator < Rails::Generators::Base
+  class PostgresqlUniqueConstraintMigrationGenerator < Rails::Generators::Base
     include Rails::Generators::Migration
     extend Unread::Generators::GeneratorHelper
 
-    desc "Generates migration for read_markers"
+    desc "Generates update migration to add unique constraint for PostgresSQL database"
     source_root File.expand_path('../templates', __FILE__)
 
     def create_migration_file
-      migration_template 'migration.rb', 'db/migrate/unread_migration.rb'
+      migration_template 'unread_postgresql_unique_constraint_migration.rb', 'db/migrate/unread_postgresql_unique_constraint_migration.rb'
     end
   end
 end

--- a/lib/generators/unread/postgresql_unique_constraint_migration/templates/unread_postgresql_unique_constraint_migration.rb
+++ b/lib/generators/unread/postgresql_unique_constraint_migration/templates/unread_postgresql_unique_constraint_migration.rb
@@ -1,0 +1,31 @@
+require 'generators/unread/migration_helper'
+
+class UnreadPostgresqlUniqueConstraintMigration < Unread::MIGRATION_BASE_CLASS
+  extend Unread::Generators::MigrationHelper
+
+  INDEX_NAME = 'read_marks_reader_readable_index'
+  INDEX_COLUMNS = [:reader_id, :reader_type, :readable_type, :readable_id]
+
+  def self.up
+    if postgresql_9_5?
+      unless index_exists?(ReadMark, INDEX_COLUMNS, unique: true)
+        add_index ReadMark, INDEX_COLUMNS, name: INDEX_NAME, unique: true
+      end
+
+      execute <<-SQL
+        ALTER TABLE #{ReadMark.table_name}
+          ADD CONSTRAINT read_marks_reader_readable_constraint UNIQUE USING INDEX #{INDEX_NAME}
+      SQL
+    end
+  end
+
+  def self.down
+    if postgresql_9_5?
+      execute <<-SQL
+        ALTER TABLE #{ReadMark.table_name}
+          DROP CONSTRAINT IF EXISTS read_marks_reader_readable_constraint
+      SQL
+      add_index ReadMark, INDEX_COLUMNS, name: INDEX_NAME, unique: true
+    end
+  end
+end

--- a/lib/unread.rb
+++ b/lib/unread.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'upsert'
 
 require 'unread/base'
 require 'unread/read_mark'
@@ -7,9 +8,11 @@ require 'unread/reader'
 require 'unread/readable_scopes'
 require 'unread/reader_scopes'
 require 'unread/garbage_collector'
+require 'unread/active_record_relation'
 require 'unread/version'
 
 ActiveRecord::Base.send :include, Unread
+ActiveRecord::Relation.send :include, ActiveRecordRelation::Unread
 
 Unread::MIGRATION_BASE_CLASS = if ActiveRecord::VERSION::MAJOR >= 5
   ActiveRecord::Migration[5.0]

--- a/lib/unread/active_record_relation.rb
+++ b/lib/unread/active_record_relation.rb
@@ -1,0 +1,7 @@
+module ActiveRecordRelation
+  module Unread
+    def mark_as_read!(options)
+      klass.mark_as_read!(self, options)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,8 @@ def setup_db
 
   ActiveRecord::Base.establish_connection(db_name.to_sym)
   ActiveRecord::Base.default_timezone = :utc
+  ActiveRecord::Base.logger = Logger.new(File.join(__dir__, "debug.log"))
+  ActiveRecord::Base.logger.level = ENV["CI"] ? ::Logger::ERROR : ::Logger::DEBUG
   ActiveRecord::Migration.verbose = false
 
   UnreadMigration.up

--- a/spec/unread/readable_spec.rb
+++ b/spec/unread/readable_spec.rb
@@ -269,9 +269,6 @@ describe Unread::Readable do
     it "should mark the rest as read when the first record is not unique" do
       Email.mark_as_read! [ @email1 ], for: @reader
 
-      allow(@email1).to receive_message_chain("read_marks.build").and_return(@email1.read_marks.build)
-      allow(@email1).to receive_message_chain("read_marks.where").and_return([])
-
       expect do
         Email.mark_as_read! [ @email1, @email2 ], for: @reader
       end.to change(ReadMark, :count).by(1)

--- a/unread.gemspec
+++ b/unread.gemspec
@@ -21,12 +21,13 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'activerecord', '>= 3'
+  s.add_dependency 'upsert', '~> 2.2.1'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'mysql2'
-  s.add_development_dependency 'pg'
+  s.add_development_dependency 'pg', '< 1'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'term-ansicolor'


### PR DESCRIPTION
by fatkodima

This PR optimizes .mark_as_read! to be roughly one query for collections and for relations.

Implements

Partly done by https://github.com/ledermann/unread/pull/93 - an optimized "one query" solution for scopes is still pending.

from https://github.com/ledermann/unread/issues/73 and fixes https://github.com/ledermann/unread/issues/80.

This is a an improvement over my previous PR https://github.com/ledermann/unread/pull/94, so probably that can be closed.

Implementation is based on INSERT ... ON CONFLICT DO ... like feature on modern databases (aka UPSERT) using [gem upsert](https://github.com/seamusabshere/upsert) which uses native support of "upsert" or emulates if db does not provide it and allows to insert many records at once without db constraint violation.

PostgresSQL requires to have a unique constraint (just index is not sufficient) as so upsert gem, as stated [on gem's readme](https://github.com/seamusabshere/upsert#native-postgres-upsert) so migration to add such was created.